### PR TITLE
Fix EIMHost plugin scan parameter

### DIFF
--- a/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
+++ b/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
@@ -104,7 +104,7 @@ class NativeAudioPluginFactoryImpl: NativeAudioPluginFactory {
                 async {
                     scanSemaphore.withPermit {
                         logger.info("Scanning native audio plugin: {}", it)
-                        val pb = ProcessBuilder(getNativeHostPath(it), "-S", "#")
+                        val pb = ProcessBuilder(getNativeHostPath(it), "-S", it)
                         pb.redirectError()
                         val process = pb.start()
                         scanningPlugins[it] = process


### PR DESCRIPTION
`"#"` -> `it`

ProcessAudioProcessorImpl.kt:ll.151-152 might need to be fixed since `"#"` is used as well.