### PR TITLE
Scan VST3 plugins correctly on Linux

### DIFF
--- a/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
+++ b/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
@@ -80,6 +80,20 @@ class NativeAudioPluginFactoryImpl: NativeAudioPluginFactory {
         scanned.addAll(skipList)
         descriptions.forEach { scanned.add(it.fileOrIdentifier) }
 
+        val scanDirectoryOnLinux = {directory: Path ->
+            if(directory.name.endsWith(".vst3")) {
+                pluginList.add(directory.absolutePathString())
+                FileVisitResult.SKIP_SUBTREE
+            }
+            FileVisitResult.CONTINUE
+        }
+
+        val scanDirectoryOnWindows = {_: Path ->
+            FileVisitResult.CONTINUE
+        }
+
+        val scanDirectory = if (SystemUtils.IS_OS_WINDOWS) scanDirectoryOnWindows else scanDirectoryOnLinux
+
         if (SystemUtils.IS_OS_MAC) {
             pluginList.addAll(getAudioUnitsForMacOS())
         } else {
@@ -88,11 +102,7 @@ class NativeAudioPluginFactoryImpl: NativeAudioPluginFactory {
                     if (directory.name.startsWith(".")) {
                         FileVisitResult.SKIP_SUBTREE
                     } else {
-                        if(directory.name.endsWith(".vst3")) {
-                            pluginList.add(directory.absolutePathString())
-                            FileVisitResult.SKIP_SUBTREE
-                        }
-                        FileVisitResult.CONTINUE
+                        scanDirectory(directory)
                     }
                 }
                 onVisitFile { file, _ ->

--- a/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
+++ b/native/src/jvmMain/kotlin/com/eimsound/dsp/native/processors/NativeAudioPluginImpl.kt
@@ -88,6 +88,10 @@ class NativeAudioPluginFactoryImpl: NativeAudioPluginFactory {
                     if (directory.name.startsWith(".")) {
                         FileVisitResult.SKIP_SUBTREE
                     } else {
+                        if(directory.name.endsWith(".vst3")) {
+                            pluginList.add(directory.absolutePathString())
+                            FileVisitResult.SKIP_SUBTREE
+                        }
                         FileVisitResult.CONTINUE
                     }
                 }


### PR DESCRIPTION
Prevents VST3 `.so` files from being scanned as LADSPA plugins

See https://steinbergmedia.github.io/vst3_dev_portal/pages/Technical+Documentation/Locations+Format/Plugin+Format.html#for-the-linux-platform